### PR TITLE
[feat] implement custom dev server

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,8 @@ module.exports = function defineShipwrightHook(sails) {
         if (process.env.NODE_ENV == 'production') {
           rsbuild.build()
         } else {
-          rsbuild.build({ mode: 'development', watch: true })
+          const { middlewares } = await rsbuild.cre
+          // rsbuild.build({ mode: 'development', watch: true })
         }
       } catch (error) {
         sails.error(error)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "sails-hook-shipwright",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sails-hook-shipwright",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@rsbuild/core": "^0.2.8"
+        "@rsbuild/core": "^0.6.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.4.3",
@@ -754,55 +754,86 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/@rsbuild/core": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.2.8.tgz",
-      "integrity": "sha512-wl9u0ZRlCfBn9mQ+1TuFbT1gi3hYy7yw8zv8i/R0v2s4ydFkUuHFMIVbeBt0peKLLKRmYS3rYF/RcXUVhbfsyQ==",
+    "node_modules/@module-federation/runtime": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.0.8.tgz",
+      "integrity": "sha512-Hi9g10aHxHdQ7CbchSvke07YegYwkf162XPOmixNmJr5Oy4wVa2d9yIVSrsWFhBRbbvM5iJP6GrSuEq6HFO3ug==",
       "dependencies": {
-        "@rsbuild/shared": "0.2.8",
-        "@rspack/core": "0.4.4",
-        "core-js": "~3.32.2",
-        "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
-        "postcss": "8.4.31"
+        "@module-federation/sdk": "0.0.8"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.0.8.tgz",
+      "integrity": "sha512-tqx3wlVHnpWLk+vn22c0x9Nv1BqdZnoS6vdMb53IsVpbQIFP70nhhvymHUyFuPkoLzMFidS7GpG58DYT/4lvCw==",
+      "dependencies": {
+        "@module-federation/runtime": "0.0.8",
+        "@module-federation/webpack-bundler-runtime": "0.0.8"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.0.8.tgz",
+      "integrity": "sha512-lkasywBItjUTNT0T0IskonDE2E/2tXE9UhUCPVoDL3NteDUSFGg4tpkF+cey1pD8mHh0XJcGrCuOW7s96peeAg=="
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.0.8.tgz",
+      "integrity": "sha512-ULwrTVzF47+6XnWybt6SIq97viEYJRv4P/DByw5h7PSX9PxSGyMm5pHfXdhcb7tno7VknL0t2V8F48fetVL9kA==",
+      "dependencies": {
+        "@module-federation/runtime": "0.0.8",
+        "@module-federation/sdk": "0.0.8"
+      }
+    },
+    "node_modules/@rsbuild/core": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-0.6.2.tgz",
+      "integrity": "sha512-FWNeVclbXRxEdOAsgNl+hvm1UKCvshR6uK1+BLYOu4QI2lmYkl/JnB3IhjyIMEIsLVU+H1QsxegvIwID7DeC5A==",
+      "dependencies": {
+        "@rsbuild/shared": "0.6.2",
+        "@rspack/core": "0.6.1",
+        "@swc/helpers": "0.5.3",
+        "core-js": "~3.36.0",
+        "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
+        "postcss": "^8.4.38"
       },
       "bin": {
         "rsbuild": "bin/rsbuild.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@rsbuild/shared": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.2.8.tgz",
-      "integrity": "sha512-87bdIgWYtFxDZGzFoJz21+RqMVLGXN40k6a00ldmaP4D+R95v/+S5NSvreG4im/kOo12RcW0LzuqE3QE0vtT6Q==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@rsbuild/shared/-/shared-0.6.2.tgz",
+      "integrity": "sha512-9p+RbD8brV4SPhOo+ccmbNXURkkn0bxJ17SSp0iOT6vGhYrglKBAtqg+XvWOTaumqrVMvfIzyCCeePveRQ5VOg==",
       "dependencies": {
-        "@rspack/core": "0.4.4",
-        "caniuse-lite": "^1.0.30001559",
-        "lodash": "^4.17.21",
-        "postcss": "8.4.31"
+        "@rspack/core": "0.6.1",
+        "caniuse-lite": "^1.0.30001607",
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.4.4.tgz",
-      "integrity": "sha512-CrZH2Vpf4Axi23GlD8qesyxmpplkYo6o5MlPuUtqNGrIA3JpPSRtBVLOE1NsMZ3+hnDHJ5GWtWoWkEB0p3beBA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-0.6.1.tgz",
+      "integrity": "sha512-Kh81wjmT7r0JiFrqyMOkuve5Pwm4Mq44m6+tywE15bDTpahDIDQ3x18fZqeSTWG4t3P0fhvljsiWWAlPvwyjOg==",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "0.4.4",
-        "@rspack/binding-darwin-x64": "0.4.4",
-        "@rspack/binding-linux-arm64-gnu": "0.4.4",
-        "@rspack/binding-linux-arm64-musl": "0.4.4",
-        "@rspack/binding-linux-x64-gnu": "0.4.4",
-        "@rspack/binding-linux-x64-musl": "0.4.4",
-        "@rspack/binding-win32-arm64-msvc": "0.4.4",
-        "@rspack/binding-win32-ia32-msvc": "0.4.4",
-        "@rspack/binding-win32-x64-msvc": "0.4.4"
+        "@rspack/binding-darwin-arm64": "0.6.1",
+        "@rspack/binding-darwin-x64": "0.6.1",
+        "@rspack/binding-linux-arm64-gnu": "0.6.1",
+        "@rspack/binding-linux-arm64-musl": "0.6.1",
+        "@rspack/binding-linux-x64-gnu": "0.6.1",
+        "@rspack/binding-linux-x64-musl": "0.6.1",
+        "@rspack/binding-win32-arm64-msvc": "0.6.1",
+        "@rspack/binding-win32-ia32-msvc": "0.6.1",
+        "@rspack/binding-win32-x64-msvc": "0.6.1"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.4.4.tgz",
-      "integrity": "sha512-40HUmnT/zHBcajcdTtIzorI1zpGZCpJBnis2rR3DzmBnD1fDLgu7PcW7iE11/MPmdwOYAZbCSzTZwe8hv0Skxw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.6.1.tgz",
+      "integrity": "sha512-VbNGprAwNDrddEzGUuy6c+Q9DVlLj8jbtKsBK8maw0ERH7csX+RiH8iK+mUUf3TVMB7egRPODCBgzluyh4smYw==",
       "cpu": [
         "arm64"
       ],
@@ -812,9 +843,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.4.4.tgz",
-      "integrity": "sha512-8vXoqA0S+D7LnwGAsO5dEpxKV3np/iONPvwRhVl2cBtsFKYmnh3jG0oxtDamCUUw38Jc3VZQTeH7kUt5F8HB5g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.6.1.tgz",
+      "integrity": "sha512-JPRSVUEHxPPNaD8H1e5dCinu/ST5UKF0PTfxL4yElbwWnujWRYhoXZAqEEImDTFIHl8pzf5asUEUt01UGpLuqw==",
       "cpu": [
         "x64"
       ],
@@ -824,9 +855,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.4.4.tgz",
-      "integrity": "sha512-lmLy9W14WcVjI1PuZVeq0TAGNFoeYjQswQHl0KCDURcxaBbVqGcNjPovhbib+5w9Gj4jQqqnVIUHs86vIqDwHQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.6.1.tgz",
+      "integrity": "sha512-XM3qcxuoH3cETolV1xE8ig169K8hJ5xUcll3bJ0xAmDOdqzXIjnlcKiXWEJbgDY5VFwOqh27SoB3xxXQQv6KPQ==",
       "cpu": [
         "arm64"
       ],
@@ -836,9 +867,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.4.4.tgz",
-      "integrity": "sha512-wnranY+QPbGzrkfNneZkq839imrt+pfup1RpynfgrvjiWApDwvagTi9S8M7Og3u9m1CmJDrBq6yXgy4ffweygQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.6.1.tgz",
+      "integrity": "sha512-WHDZew5i/Vts5MOyFwwjkfZrPehx9d6Zx/dGSsUriyu+bFmJGNnvSPpcpJejL9t0GNsjs1EL7K5fjwXro3qABA==",
       "cpu": [
         "arm64"
       ],
@@ -848,9 +879,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.4.4.tgz",
-      "integrity": "sha512-J0n+91NL9quEWYaStFitXC3+rbM+wklxCEHvkwfuzC46fGcG9673aTVfcrod1fx2jTHHaftXKb5Hpru77W0JAA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.6.1.tgz",
+      "integrity": "sha512-bvexuC7ad2hbIDWRURAdwvMHoJmDLL+W2iaQp2xe7x1WKaGt5fT6ZePAth+f0xro+PuAbnfJ5H3J++xvqvAUHA==",
       "cpu": [
         "x64"
       ],
@@ -860,9 +891,9 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.4.4.tgz",
-      "integrity": "sha512-ulIhvLzimHB5Ggp9TRJEFvyak/7OPzeVxFdP8nYNBHzPoYiqnK2MQUVOK7CT2hTpco1QJbh3jZTZxzdKIY5asw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.6.1.tgz",
+      "integrity": "sha512-o4P54sUVaHVYyCd6KAUgBNOkBVD39xOyjpK3Ob8+lmrunDAzw6hbE2tMORMm9BfaCeKh+F17VthPjTlFgQsRRg==",
       "cpu": [
         "x64"
       ],
@@ -872,9 +903,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.4.4.tgz",
-      "integrity": "sha512-t4u3jlx+0LDOY7Y8m9tLDHAsPN9aiyz/5NDHKqdDeke5NJZ2A4jbv+h/dvcyGH+Nxj056XW1aa9wzvzT9jb//A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.6.1.tgz",
+      "integrity": "sha512-6OoPlxZH2j+k1JyzO0khbtodJmXgpscx7sa6i2HvUsSWJVxAAjMf2ZdRsDGwMxATp9S9HIDklqV7h2X9/nfIvg==",
       "cpu": [
         "arm64"
       ],
@@ -884,9 +915,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.4.4.tgz",
-      "integrity": "sha512-ijw4bmB8Zh8BkawPqIc8Q7VWr6bSw9trMqTtXwHrXAyKYCdyXMCYsGnj7Rc6CKKrV6D6nsDXtA8ANFqoKCuvyw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.6.1.tgz",
+      "integrity": "sha512-eJ+WNrEymxFBAB187fFobCS3MUc1afCv0EzAs9LAVPgj2Z3fE8l2XCDUPsRkGtQyh8ftTdyyY9JNqYEIOrx4RQ==",
       "cpu": [
         "ia32"
       ],
@@ -896,9 +927,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.4.4.tgz",
-      "integrity": "sha512-jpJPjfNTEbHBCOuZotXhpBpR0C1jTvHh6wlgPjP286JXaAhGv/PEzriuRdXw0RSet1tf1vqn/V4lFU5hZbXZIA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.6.1.tgz",
+      "integrity": "sha512-Wk/p1jwcjICKOGLmUkrbUZTZ5yQuYJEjNhMyAZDBQtQMOqkycOsijw8c/KYEfJTzSK0TuE+5rK5WDqQkGaYFoQ==",
       "cpu": [
         "x64"
       ],
@@ -908,21 +939,19 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.4.4.tgz",
-      "integrity": "sha512-SL6g6ZPPOqPI1wuQrZlSXD73HUg7GO5+wFRSATRak9hZ3wzSvYmD0kRGSCc6Kpndn21pmMLeOXNHbk2bL+x37g==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-0.6.1.tgz",
+      "integrity": "sha512-DBlyxm0cyxJ0WiYLeirdJghLhKovLXDhZiQZovZPTFljd1ZX1lCDvTj11KApmW8eJDoiBi0QDYWRLXeZetGllg==",
       "dependencies": {
-        "@rspack/binding": "0.4.4",
-        "@swc/helpers": "0.5.1",
+        "@module-federation/runtime-tools": "0.0.8",
+        "@rspack/binding": "0.6.1",
         "browserslist": "^4.21.3",
-        "compare-versions": "6.0.0-rc.1",
         "enhanced-resolve": "5.12.0",
+        "events": "^3.3.0",
         "graceful-fs": "4.2.10",
         "json-parse-even-better-errors": "^3.0.0",
         "neo-async": "2.6.2",
-        "react-refresh": "0.14.0",
         "tapable": "2.2.1",
-        "terminal-link": "^2.1.1",
         "watchpack": "^2.4.0",
         "webpack-sources": "3.2.3",
         "zod": "^3.21.4",
@@ -930,12 +959,20 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-      "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.3.tgz",
+      "integrity": "sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -975,20 +1012,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -1049,9 +1072,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1067,8 +1090,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
         "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
@@ -1115,9 +1138,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001571",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001571.tgz",
-      "integrity": "sha512-tYq/6MoXhdezDLFZuCO/TKboTzuQ/xR5cFdgXPfDtM7/kchBO3b4VWghE/OAi/DV7tTdhmLjZiZBZi1fA/GheQ==",
+      "version": "1.0.30001610",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001610.tgz",
+      "integrity": "sha512-QFutAY4NgaelojVMjY63o6XlZyORPaLfyMnsl3HgnWdJUcX6K0oaJymHjH8PT5Gk7sTm8rvC/c5COUQKXqmOMA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1330,11 +1353,6 @@
         "dot-prop": "^5.1.0"
       }
     },
-    "node_modules/compare-versions": {
-      "version": "6.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
-      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
-    },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -1378,9 +1396,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.32.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
-      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.1.tgz",
+      "integrity": "sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -1517,9 +1535,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.616",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz",
-      "integrity": "sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg=="
+      "version": "1.4.736",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.736.tgz",
+      "integrity": "sha512-Rer6wc3ynLelKNM4lOCg7/zPQj8tPOCB2hzD32PX9wd3hgRRi9MxEbmkFCokzcEhRVMiOVLjnL9ig9cefJ+6+Q=="
     },
     "node_modules/emoji-regex": {
       "version": "10.3.0",
@@ -1570,6 +1588,14 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -1793,6 +1819,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1823,9 +1850,9 @@
     },
     "node_modules/html-webpack-plugin": {
       "name": "html-rspack-plugin",
-      "version": "5.5.7",
-      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.5.7.tgz",
-      "integrity": "sha512-7dNAURj9XBHWoYg59F8VU6hT7J7w+od4Lr5hc/rrgN6sy6QfqVpoPqW9Qw4IGFOgit8Pul7iQp1yysBSIhOlsg==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/html-rspack-plugin/-/html-rspack-plugin-5.6.2.tgz",
+      "integrity": "sha512-cPGwV3odvKJ7DBAG/DxF5e0nMMvBl1zGfyDciT2xMETRrIwajwC7LtEB3cf7auoGMK6xJOOLjWJgaKHLu/FzkQ==",
       "dependencies": {
         "lodash": "^4.17.21",
         "tapable": "^2.0.0"
@@ -1836,6 +1863,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/html-webpack-plugin"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || 1.x"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/human-signals": {
@@ -2625,9 +2660,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -2643,9 +2678,9 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2682,14 +2717,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/react-refresh": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/read-pkg": {
@@ -3041,9 +3068,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3167,20 +3194,9 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -3204,21 +3220,6 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/text-extensions": {
@@ -3273,17 +3274,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/typescript": {
       "version": "5.3.3",
@@ -3369,9 +3359,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
+      "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hookName": "shipwright"
   },
   "dependencies": {
-    "@rsbuild/core": "^0.2.8"
+    "@rsbuild/core": "^0.6.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",


### PR DESCRIPTION
With the release of [Rsbuild >= 0.5.0](https://rsbuild.dev/community/releases/v0-5#-support-for-custom-server), Rsbuild now ships with the ability to replace the dev server with a custom dev server that amongst other things allow for implementations like Shipwright to support hot update features.

This PR updates Rsbuild dependency and also implement the custom dev server in Shipwright.