### PR TITLE
[fix] update config to disable output hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function defineShipwrightHook(sails) {
           }
         },
         output: {
-          filenameHash: true,
+          filenameHash: false,
           distPath: {
             root: '.tmp/public',
             css: 'css',

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function defineShipwrightHook(sails) {
           }
         },
         output: {
-          disableFilenameHash: true,
+          filenameHash: true,
           distPath: {
             root: '.tmp/public',
             css: 'css',


### PR DESCRIPTION
As of Rsbuild version `0.4.0` and above the config to disable output hash has been changed from `output.disableFilenameHash` to `output.filenameHash`. This PR updates Shipwright's config to match the new API.