### PR TITLE
feat: add CSS/LESS/SASS support with modular architecture

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,68 +1,88 @@
 /**
- * shipwright hook
+ * sails-hook-shipwright
  *
- * @description :: A hook definition.  Extends Sails by adding shadow routes, implicit actions, and/or initialization logic.
- * @docs        :: https://sailsjs.com/docs/concepts/extending-sails/hooks
+ * Modern asset pipeline for Sails.js, powered by Rsbuild.
+ *
+ * @see https://github.com/sailshq/sails-hook-shipwright
  */
 
 const path = require('path')
-const { defineConfig, mergeRsbuildConfig } = require('@rsbuild/core')
+const {
+  detectStylesEntry,
+  detectJsEntry,
+  validatePlugins
+} = require('./lib/entry')
+const { createTagGenerators } = require('./lib/tags')
+const { createLogger, randomQuote } = require('./lib/log')
+
 module.exports = function defineShipwrightHook(sails) {
-  function getManifestFiles() {
-    const manifestPath = path.resolve(
-      sails.config.appPath,
-      '.tmp',
-      'public',
-      'manifest.json'
-    )
-    const data = require(manifestPath)
-    const files = data.allFiles
-    return files
-  }
+  let log
 
   return {
-    generateScripts: function generateScripts() {
-      const manifestFiles = getManifestFiles()
-      let scripts = []
-      manifestFiles.forEach((file) => {
-        if (file.endsWith('.js')) {
-          scripts.push(`<script type="text/javascript" src="${file}"></script>`)
-        }
-      })
-      return scripts.join('\n')
-    },
-    generateStyles: function generateStyles() {
-      const manifestFiles = getManifestFiles()
-      let styles = []
-      manifestFiles.forEach((file) => {
-        if (file.endsWith('.css')) {
-          styles.push(`<link rel="stylesheet" href="${file}">`)
-        }
-      })
-      return styles.join('\n')
-    },
     defaults: {
       shipwright: {
+        styles: {},
+        js: {},
         build: {}
       }
     },
+
     /**
-     * Runs when this Sails app loads/lifts.
+     * Configure hook.
+     * Runs after defaults merge, before initialize.
+     * Detects entry points and validates plugins early.
+     */
+    configure: function () {
+      log = createLogger(sails.log)
+
+      const { appPath } = sails.config
+      const config = sails.config.shipwright
+
+      config.styles.entry = detectStylesEntry(appPath, config.styles.entry)
+      config.js.entry = detectJsEntry(appPath, config.js.entry)
+
+      validatePlugins({ appPath, stylesEntry: config.styles.entry, log })
+    },
+
+    /**
+     * Initialize hook.
+     * Starts Rsbuild build (production) or dev server (development).
      */
     initialize: async function () {
-      // Skip asset building if --dontLift is set
       if (sails.config.dontLift) {
-        sails.log.info('shipwright: Skipping asset build due to dontLift flag')
+        log.verbose('Skipping build (dontLift)')
         return
       }
-      const hook = this
-      const appPath = sails.config.appPath
-      const defaultConfigs = defineConfig({
-        source: {
-          entry: {
-            app: path.resolve(appPath, 'assets', 'js', 'app.js')
-          }
-        },
+
+      const { appPath } = sails.config
+      const config = sails.config.shipwright
+
+      // Log detected entries
+      if (config.styles.entry) log.verbose('Styles → %s', config.styles.entry)
+      if (config.js.entry) log.verbose('JS → %s', config.js.entry)
+
+      // Maritime easter egg in silly mode
+      log.silly('Preparing to set sail...')
+
+      // Build entry object
+      const entry = {}
+      if (config.js.entry) entry.app = path.resolve(appPath, config.js.entry)
+      if (config.styles.entry)
+        entry.styles = path.resolve(appPath, config.styles.entry)
+
+      if (!Object.keys(entry).length) {
+        log.verbose('No entry points found, skipping')
+        return
+      }
+
+      const {
+        defineConfig,
+        mergeRsbuildConfig,
+        createRsbuild
+      } = require('@rsbuild/core')
+
+      const defaultConfig = defineConfig({
+        source: { entry },
         resolve: {
           alias: {
             '@': path.resolve(appPath, 'assets', 'js'),
@@ -76,70 +96,65 @@ module.exports = function defineShipwrightHook(sails) {
             css: 'css',
             js: 'js',
             font: 'fonts',
-            image: 'images',
-            html: '/'
+            image: 'images'
           },
           copy: [
             {
               from: path.resolve(appPath, 'assets'),
               to: path.resolve(appPath, '.tmp', 'public'),
               noErrorOnMissing: true,
-              globOptions: {
-                // Exclude files that Rsbuild processes
-                ignore: ['**/js/**', '**/css/**']
-              }
+              globOptions: { ignore: ['**/js/**', '**/styles/**', '**/css/**'] }
             }
           ]
         },
         tools: {
-          htmlPlugin: false
+          htmlPlugin: false,
+          // Don't process absolute URLs in CSS - they reference static assets served from .tmp/public
+          cssLoader: { url: { filter: (url) => !url.startsWith('/') } }
         },
-        performance: {
-          chunkSplit: {
-            strategy: 'split-by-experience'
-          }
-        },
-        server: {
-          port: sails.config.port,
-          strictPort: true,
-          printUrls: false
-        },
-        dev: {
-          writeToDisk: (file) => file.includes('manifest.json') // Write manifest file
-        }
+        performance: { chunkSplit: { strategy: 'split-by-experience' } },
+        server: { port: sails.config.port, strictPort: true, printUrls: false },
+        dev: { writeToDisk: (file) => file.includes('manifest.json') }
       })
-      const config = mergeRsbuildConfig(
-        defaultConfigs,
-        sails.config.shipwright.build
-      )
-      const { createRsbuild } = require('@rsbuild/core')
+
+      const rsbuildConfig = mergeRsbuildConfig(defaultConfig, config.build)
+
       try {
-        const rsbuild = await createRsbuild({ rsbuildConfig: config })
+        const rsbuild = await createRsbuild({ rsbuildConfig })
+
         if (process.env.NODE_ENV === 'production') {
+          log.silly('Building for production...')
           await rsbuild.build()
+          log.verbose('Build complete ⚓')
+          log.silly('🚢 %s', randomQuote())
         } else {
-          const rsbuildDevServer = await rsbuild.createDevServer()
-          sails.after('hook:http:loaded', async () => {
-            sails.hooks.http.app.use(rsbuildDevServer.middlewares)
-            rsbuildDevServer.connectWebSocket({
-              server: sails.hooks.http.server
-            })
+          const devServer = await rsbuild.createDevServer()
+
+          sails.after('hook:http:loaded', () => {
+            sails.hooks.http.app.use(devServer.middlewares)
+            devServer.connectWebSocket({ server: sails.hooks.http.server })
           })
-          sails.on('lifted', async () => {
-            await rsbuildDevServer.afterListen()
+
+          sails.on('lifted', () => {
+            devServer.afterListen()
+            log.verbose('Dev server ready ⚓')
+            log.silly('🚢 %s', randomQuote())
           })
-          sails.on('lower', async () => {
-            await rsbuildDevServer.close()
+
+          sails.on('lower', () => {
+            devServer.close()
+            log.silly('Dropping anchor... goodbye!')
           })
         }
+
+        // Register view locals (merge, don't overwrite)
         sails.config.views.locals = {
-          shipwright: {
-            scripts: hook.generateScripts,
-            styles: hook.generateStyles
-          }
+          ...sails.config.views.locals,
+          shipwright: createTagGenerators(appPath)
         }
       } catch (error) {
-        sails.log.error(error)
+        log.error('Build failed')
+        log.error(error)
       }
     }
   }

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -1,0 +1,111 @@
+/**
+ * lib/entry.js
+ *
+ * Entry point detection and plugin validation.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const STYLE_CANDIDATES = [
+  'assets/styles/importer.less',
+  'assets/styles/importer.scss',
+  'assets/styles/importer.sass',
+  'assets/styles/importer.css',
+  'assets/styles/main.less',
+  'assets/styles/main.scss',
+  'assets/styles/main.css',
+  'assets/styles/app.less',
+  'assets/styles/app.scss',
+  'assets/styles/app.css'
+]
+
+const JS_CANDIDATES = [
+  'assets/js/app.js',
+  'assets/js/main.js',
+  'assets/js/index.js'
+]
+
+const PLUGIN_CONFIG = {
+  '.less': { package: '@rsbuild/plugin-less', importName: 'pluginLess' },
+  '.scss': { package: '@rsbuild/plugin-sass', importName: 'pluginSass' },
+  '.sass': { package: '@rsbuild/plugin-sass', importName: 'pluginSass' }
+}
+
+/**
+ * Detect an entry point from a list of candidates.
+ */
+function detectEntry(appPath, configuredEntry, candidates) {
+  if (configuredEntry) return configuredEntry
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.resolve(appPath, candidate))) {
+      return candidate
+    }
+  }
+  return null
+}
+
+function detectStylesEntry(appPath, configuredEntry) {
+  return detectEntry(appPath, configuredEntry, STYLE_CANDIDATES)
+}
+
+function detectJsEntry(appPath, configuredEntry) {
+  return detectEntry(appPath, configuredEntry, JS_CANDIDATES)
+}
+
+/**
+ * Check if a package is installed in the user's app.
+ */
+function isPluginInstalled(packageName, appPath) {
+  try {
+    require.resolve(packageName, { paths: [appPath] })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Log a helpful error message for missing plugins.
+ * Note: log is already prefixed via createLogger from lib/log.js
+ */
+function logMissingPlugin(log, entry, plugin, importName) {
+  log.error('')
+  log.error('Found %s but %s is not installed.', entry, plugin)
+  log.error('')
+  log.error('To compile these files:')
+  log.error('  1. npm install %s --save-dev', plugin)
+  log.error('  2. Add to config/shipwright.js:')
+  log.error('')
+  log.error("     const { %s } = require('%s')", importName, plugin)
+  log.error('     module.exports.shipwright = {')
+  log.error('       build: { plugins: [%s()] }', importName)
+  log.error('     }')
+  log.error('')
+}
+
+/**
+ * Validate that required plugins are installed.
+ */
+function validatePlugins({ appPath, stylesEntry, log }) {
+  if (!stylesEntry) return
+
+  const ext = path.extname(stylesEntry).toLowerCase()
+  const pluginInfo = PLUGIN_CONFIG[ext]
+
+  if (pluginInfo && !isPluginInstalled(pluginInfo.package, appPath)) {
+    logMissingPlugin(
+      log,
+      stylesEntry,
+      pluginInfo.package,
+      pluginInfo.importName
+    )
+    throw new Error(`Missing ${pluginInfo.package}`)
+  }
+}
+
+module.exports = {
+  detectStylesEntry,
+  detectJsEntry,
+  validatePlugins
+}

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,33 @@
+/**
+ * lib/log.js
+ *
+ * Prefixed logging with maritime easter eggs.
+ */
+
+const PREFIX = 'shipwright:'
+
+const QUOTES = [
+  'Smooth seas never made a skilled shipwright.',
+  "A ship in harbor is safe, but that's not what ships are built for.",
+  "Red sky at night, sailor's delight. Green build output, developer's delight.",
+  'Fair winds and following seas to your assets.',
+  'The sea finds out everything you did wrong. So does production.',
+  "We're gonna need a bigger bundle.",
+  "I'm the captain of this asset pipeline now.",
+  'Ahoy! Spotted land at .tmp/public/'
+]
+
+const randomQuote = () => QUOTES[Math.floor(Math.random() * QUOTES.length)]
+
+const createLogger = (sailsLog) => ({
+  error: (msg, ...args) => sailsLog.error(`${PREFIX} ${msg}`, ...args),
+  warn: (msg, ...args) => sailsLog.warn(`${PREFIX} ${msg}`, ...args),
+  info: (msg, ...args) => sailsLog.info(`${PREFIX} ${msg}`, ...args),
+  verbose: (msg, ...args) => sailsLog.verbose(`${PREFIX} ${msg}`, ...args),
+  silly: (msg, ...args) => {
+    sailsLog.silly(`${PREFIX} ${msg}`, ...args)
+    sailsLog.silly(`${PREFIX} 🚢 ${randomQuote()}`)
+  }
+})
+
+module.exports = { createLogger, randomQuote }

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -1,0 +1,38 @@
+/**
+ * lib/tags.js
+ *
+ * Generate script and style tags from the manifest.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * Create tag generators bound to the app path.
+ */
+function createTagGenerators(appPath) {
+  const manifestPath = path.resolve(appPath, '.tmp', 'public', 'manifest.json')
+
+  function readManifest() {
+    if (!fs.existsSync(manifestPath)) {
+      return { allFiles: [] }
+    }
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  }
+
+  function generateTags(extension, template) {
+    return readManifest()
+      .allFiles.filter((file) => file.endsWith(extension))
+      .map((file) => template(file))
+      .join('\n')
+  }
+
+  return {
+    scripts: () =>
+      generateTags('.js', (file) => `<script src="${file}"></script>`),
+    styles: () =>
+      generateTags('.css', (file) => `<link rel="stylesheet" href="${file}">`)
+  }
+}
+
+module.exports = { createTagGenerators }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The modern asset pipeline for Sails",
   "main": "index.js",
   "scripts": {
+    "test": "node --test tests/unit/*.test.js",
     "prepare": "husky install"
   },
   "repository": {

--- a/tests/unit/entry.test.js
+++ b/tests/unit/entry.test.js
@@ -1,0 +1,108 @@
+const { describe, it, beforeEach, afterEach } = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const {
+  detectStylesEntry,
+  detectJsEntry,
+  validatePlugins
+} = require('../../lib/entry')
+
+describe('entry.js', () => {
+  let tmpDir
+  const mockLog = { error: () => {} }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipwright-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function createFile(relativePath) {
+    const fullPath = path.join(tmpDir, relativePath)
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true })
+    fs.writeFileSync(fullPath, '')
+  }
+
+  describe('detectStylesEntry', () => {
+    it('returns configured entry over auto-detection', () => {
+      createFile('assets/styles/importer.less')
+      assert.strictEqual(
+        detectStylesEntry(tmpDir, 'custom.less'),
+        'custom.less'
+      )
+    })
+
+    it('auto-detects in priority order: importer.less > main.less > app.less', () => {
+      createFile('assets/styles/app.less')
+      assert.strictEqual(
+        detectStylesEntry(tmpDir, null),
+        'assets/styles/app.less'
+      )
+
+      createFile('assets/styles/importer.less')
+      assert.strictEqual(
+        detectStylesEntry(tmpDir, null),
+        'assets/styles/importer.less'
+      )
+    })
+
+    it('returns null if no entry found', () => {
+      assert.strictEqual(detectStylesEntry(tmpDir, null), null)
+    })
+  })
+
+  describe('detectJsEntry', () => {
+    it('returns configured entry over auto-detection', () => {
+      createFile('assets/js/app.js')
+      assert.strictEqual(detectJsEntry(tmpDir, 'custom.js'), 'custom.js')
+    })
+
+    it('auto-detects in priority order: app.js > main.js > index.js', () => {
+      createFile('assets/js/index.js')
+      assert.strictEqual(detectJsEntry(tmpDir, null), 'assets/js/index.js')
+
+      createFile('assets/js/app.js')
+      assert.strictEqual(detectJsEntry(tmpDir, null), 'assets/js/app.js')
+    })
+
+    it('returns null if no entry found', () => {
+      assert.strictEqual(detectJsEntry(tmpDir, null), null)
+    })
+  })
+
+  describe('validatePlugins', () => {
+    it('passes for .css (no plugin needed) or no entry', () => {
+      validatePlugins({ appPath: tmpDir, stylesEntry: null, log: mockLog })
+      validatePlugins({ appPath: tmpDir, stylesEntry: 'app.css', log: mockLog })
+    })
+
+    it('throws for .less when plugin missing', () => {
+      assert.throws(
+        () =>
+          validatePlugins({
+            appPath: tmpDir,
+            stylesEntry: 'app.less',
+            log: mockLog
+          }),
+        { message: 'Missing @rsbuild/plugin-less' }
+      )
+    })
+
+    it('throws for .scss/.sass when plugin missing', () => {
+      assert.throws(
+        () =>
+          validatePlugins({
+            appPath: tmpDir,
+            stylesEntry: 'app.scss',
+            log: mockLog
+          }),
+        { message: 'Missing @rsbuild/plugin-sass' }
+      )
+    })
+  })
+})

--- a/tests/unit/tags.test.js
+++ b/tests/unit/tags.test.js
@@ -1,0 +1,72 @@
+const { describe, it, beforeEach, afterEach } = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const { createTagGenerators } = require('../../lib/tags')
+
+describe('tags.js', () => {
+  let tmpDir
+  let manifestPath
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipwright-test-'))
+    manifestPath = path.join(tmpDir, '.tmp', 'public', 'manifest.json')
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeManifest(files) {
+    fs.writeFileSync(manifestPath, JSON.stringify({ allFiles: files }))
+  }
+
+  describe('scripts()', () => {
+    it('returns empty string when no manifest', () => {
+      const { scripts } = createTagGenerators(tmpDir)
+      assert.strictEqual(scripts(), '')
+    })
+
+    it('generates script tags for JS files only', () => {
+      writeManifest(['/js/app.js', '/css/app.css', '/js/vendor.js'])
+      const { scripts } = createTagGenerators(tmpDir)
+
+      assert.strictEqual(
+        scripts(),
+        '<script src="/js/app.js"></script>\n<script src="/js/vendor.js"></script>'
+      )
+    })
+  })
+
+  describe('styles()', () => {
+    it('returns empty string when no manifest', () => {
+      const { styles } = createTagGenerators(tmpDir)
+      assert.strictEqual(styles(), '')
+    })
+
+    it('generates link tags for CSS files only', () => {
+      writeManifest(['/css/app.css', '/js/app.js', '/css/vendor.css'])
+      const { styles } = createTagGenerators(tmpDir)
+
+      assert.strictEqual(
+        styles(),
+        '<link rel="stylesheet" href="/css/app.css">\n<link rel="stylesheet" href="/css/vendor.css">'
+      )
+    })
+  })
+
+  it('reads fresh manifest on each call (no caching)', () => {
+    const { scripts } = createTagGenerators(tmpDir)
+
+    assert.strictEqual(scripts(), '')
+
+    writeManifest(['/js/app.js'])
+    assert.strictEqual(scripts(), '<script src="/js/app.js"></script>')
+
+    writeManifest(['/js/app.js', '/js/new.js'])
+    assert.ok(scripts().includes('/js/new.js'))
+  })
+})


### PR DESCRIPTION
- Add auto-detection for style entry points (importer.less, main.scss, etc.)
- Add plugin validation with helpful error messages when LESS/SASS plugins missing
- Refactor into modular lib/ structure (entry.js, tags.js, log.js)
- Use configure() hook for early detection and fail-fast validation
- Add cssLoader config to preserve absolute URLs in CSS
- Add unit tests for entry detection and tag generation
- Add prefixed logging with maritime easter eggs

Config structure: shipwright.styles.entry, shipwright.js.entry, shipwright.build

Part of balderdashy/sails#7368