### PR TITLE
feat: enable Rsbuild 1.7 runtime error overlay and build size diff

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,10 @@ module.exports = function defineShipwrightHook(sails) {
           // Don't process absolute URLs in CSS - they reference static assets served from .tmp/public
           cssLoader: { url: { filter: (url) => !url.startsWith('/') } }
         },
-        performance: { chunkSplit: { strategy: 'split-by-experience' } },
+        performance: {
+          chunkSplit: { strategy: 'split-by-experience' },
+          printFileSize: { diff: true }
+        },
         server: { port: sails.config.port, strictPort: true, printUrls: false },
         dev: { writeToDisk: (file) => file.includes('manifest.json') }
       })

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const { createLogger, randomQuote } = require('./lib/log')
 
 module.exports = function defineShipwrightHook(sails) {
   let log
+  let tagGenerators
 
   return {
     defaults: {
@@ -44,15 +45,23 @@ module.exports = function defineShipwrightHook(sails) {
 
       validatePlugins({ appPath, stylesEntry: config.styles.entry, log })
 
-      // Register view locals early so other hooks/plugins can use them
+      // Create tag generators early so other hooks can use them
+      tagGenerators = createTagGenerators(appPath, {
+        jsInject: config.js.inject,
+        cssInject: config.styles.inject
+      })
+
+      // Register view locals
+      sails.config.views = sails.config.views || {}
       sails.config.views.locals = {
         ...sails.config.views.locals,
-        shipwright: createTagGenerators(appPath, {
-          jsInject: config.js.inject,
-          cssInject: config.styles.inject
-        })
+        shipwright: tagGenerators
       }
     },
+
+    // Expose tag generators on hook for other hooks to use
+    scripts: () => tagGenerators?.scripts() || '',
+    styles: () => tagGenerators?.styles() || '',
 
     /**
      * Initialize hook.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-shipwright",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The modern asset pipeline for Sails",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Closes balderdashy/sails#7370

## Summary
- Enable runtime error overlay in dev mode to display JS errors directly in the browser
- Enable build size diff reporting for production builds to track bundle size changes

## What's New

### Runtime Error Overlay (Development)
Shows JavaScript runtime errors directly in the browser overlay instead of just the console. Catches common Boring Stack errors like:
- `TypeError` in parasails page components
- Failed Cloud SDK calls
- Missing component registrations

### Build Size Diff (Production)
Reports file size changes between builds, helping catch unexpected bundle bloat before deployment.

## References
- [Rsbuild 1.7 Announcement](https://rspack.rs/blog/announcing-rspack-1-7)

## Test plan
- [x] Run `sails lift` in development and trigger a runtime error to verify overlay appears
- [ ] Run `npm start` twice(the second time after adding some code) and verify size diff appears