### PR TITLE
Support Rsbuild 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ _Benchmarks from [fleetdm.com](https://fleetdm.com) migration ([fleetdm/fleet#38
 npm install sails-hook-shipwright --save
 ```
 
+## Runtime Requirements
+
+Shipwright uses Rsbuild 2.x and requires Node.js `20.19+` or `22.12+`.
+This matches Rsbuild's supported runtime floor now that Node.js 18 is no
+longer supported by Rsbuild.
+
 Disable the grunt hook in `.sailsrc`:
 
 ```json
@@ -270,14 +276,36 @@ module.exports.shipwright = {
     output: {
       // Custom output options
     },
-    performance: {
-      // Custom performance options
+    splitChunks: {
+      // Custom chunk splitting options
     }
   }
 }
 ```
 
 See [Rsbuild Configuration](https://rsbuild.dev/config/) for all available options.
+
+## Rsbuild 2 Notes
+
+Shipwright is built on Rsbuild 2.x, which includes Rspack 2.x. Most apps can
+continue using the same `config/shipwright.js`, but a few advanced Rsbuild
+options changed:
+
+- `performance.chunkSplit` is deprecated. Migrate custom chunk-splitting config
+  to `splitChunks`.
+- `server.proxy` uses `http-proxy-middleware` v4. If you configure proxies,
+  replace `context` with `pathFilter` and move proxy event callbacks under the
+  `on` option.
+- `core-js` is no longer installed by Rsbuild by default. Install `core-js`
+  directly if you enable `output.polyfill`.
+- Webpack provider support was removed by Rsbuild. Shipwright's defaults use
+  Rspack only.
+- Rsbuild's default web targets are more modern. Add a browserslist config if
+  your app needs the older Rsbuild 1 browser baseline.
+
+Rsbuild 2 is published as ESM. Shipwright loads it through dynamic `import()`
+from the Sails hook, and Node.js `20.19+` can still load Rsbuild plugin packages
+from CommonJS Sails config files.
 
 ## Migrating from Grunt
 

--- a/README.md
+++ b/README.md
@@ -298,10 +298,24 @@ options changed:
   `on` option.
 - `core-js` is no longer installed by Rsbuild by default. Install `core-js`
   directly if you enable `output.polyfill`.
+- Module Federation runtime packages are no longer installed implicitly. Install
+  the federation runtime tooling your app uses before enabling Module
+  Federation config.
+- Bundle analysis is no longer provided by `performance.bundleAnalyze`. Use
+  Rsdoctor or add an explicit analyzer plugin in `build.plugins`.
 - Webpack provider support was removed by Rsbuild. Shipwright's defaults use
   Rspack only.
 - Rsbuild's default web targets are more modern. Add a browserslist config if
   your app needs the older Rsbuild 1 browser baseline.
+- Node builds target Node.js 20 by default and emit ESM by default in Rsbuild 2.
+  Set explicit Rsbuild output options if your app has a custom Node bundle.
+- Decorator transforms now default to the `2023-11` decorators proposal. Apps
+  using legacy decorators should configure the transform explicitly.
+- Audit advanced Rsbuild overrides when upgrading. Removed or deprecated options
+  include `source.alias`, `source.aliasStrategy`, `performance.bundleAnalyze`,
+  `performance.removeMomentLocale`, `performance.profile`, webpack provider
+  tooling, `dev.setupMiddlewares`, `?__inline=false`, and customized built-in
+  JS/CSS rules.
 
 Rsbuild 2 is published as ESM. Shipwright loads it through dynamic `import()`
 from the Sails hook, and Node.js `20.19+` can still load Rsbuild plugin packages

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const {
 } = require('./lib/entry')
 const { createTagGenerators } = require('./lib/tags')
 const { createLogger, randomQuote } = require('./lib/log')
+const { createDefaultRsbuildConfig } = require('./lib/rsbuild-config')
 
 module.exports = function defineShipwrightHook(sails) {
   let log
@@ -107,58 +108,16 @@ module.exports = function defineShipwrightHook(sails) {
         return
       }
 
-      const {
-        defineConfig,
-        mergeRsbuildConfig,
-        createRsbuild
-      } = require('@rsbuild/core')
+      const { defineConfig, mergeRsbuildConfig, createRsbuild } =
+        await import('@rsbuild/core')
 
-      const defaultConfig = defineConfig({
-        source: { entry },
-        resolve: {
-          alias: {
-            '@': path.resolve(appPath, 'assets', 'js'),
-            '~': path.resolve(appPath, 'assets')
-          }
-        },
-        output: {
-          manifest: true,
-          distPath: {
-            root: '.tmp/public',
-            css: 'css',
-            js: 'js',
-            font: 'fonts',
-            image: 'images'
-          },
-          copy: [
-            {
-              from: path.resolve(appPath, 'assets'),
-              to: path.resolve(appPath, '.tmp', 'public'),
-              noErrorOnMissing: true,
-              globOptions: { ignore: ['**/js/**', '**/styles/**', '**/css/**'] }
-            }
-          ]
-        },
-        tools: {
-          htmlPlugin: false,
-          // Don't process absolute URLs in CSS - they reference static assets served from .tmp/public
-          cssLoader: { url: { filter: (url) => !url.startsWith('/') } },
-          rspack: {
-            watchOptions: {
-              // Only watch assets/ and node_modules/ — ignore top-level data
-              // directories (e.g. db/ from sails-disk) so non-source filesystem
-              // writes don't trigger rebuilds.
-              ignored: /^(?!.*[\\/](assets|node_modules)[\\/])/
-            }
-          }
-        },
-        performance: {
-          chunkSplit: { strategy: 'split-by-experience' },
-          printFileSize: { diff: true }
-        },
-        server: { port: sails.config.port, strictPort: true, printUrls: false },
-        dev: { writeToDisk: (file) => file.includes('manifest.json') }
-      })
+      const defaultConfig = defineConfig(
+        createDefaultRsbuildConfig({
+          appPath,
+          entry,
+          port: sails.config.port
+        })
+      )
 
       const rsbuildConfig = mergeRsbuildConfig(defaultConfig, config.build)
 

--- a/lib/rsbuild-config.js
+++ b/lib/rsbuild-config.js
@@ -1,0 +1,58 @@
+/**
+ * lib/rsbuild-config.js
+ *
+ * Default Rsbuild configuration for the Sails integration.
+ */
+
+const path = require('path')
+
+function createDefaultRsbuildConfig({ appPath, entry, port }) {
+  return {
+    source: { entry },
+    resolve: {
+      alias: {
+        '@': path.resolve(appPath, 'assets', 'js'),
+        '~': path.resolve(appPath, 'assets')
+      }
+    },
+    output: {
+      manifest: true,
+      distPath: {
+        root: '.tmp/public',
+        css: 'css',
+        js: 'js',
+        font: 'fonts',
+        image: 'images'
+      },
+      copy: [
+        {
+          from: path.resolve(appPath, 'assets'),
+          to: path.resolve(appPath, '.tmp', 'public'),
+          noErrorOnMissing: true,
+          globOptions: { ignore: ['**/js/**', '**/styles/**', '**/css/**'] }
+        }
+      ]
+    },
+    tools: {
+      htmlPlugin: false,
+      // Don't process absolute URLs in CSS - they reference static assets served from .tmp/public
+      cssLoader: { url: { filter: (url) => !url.startsWith('/') } },
+      rspack: {
+        watchOptions: {
+          // Only watch assets/ and node_modules/ - ignore top-level data
+          // directories (e.g. db/ from sails-disk) so non-source filesystem
+          // writes don't trigger rebuilds.
+          ignored: /^(?!.*[\\/](assets|node_modules)[\\/])/
+        }
+      }
+    },
+    performance: {
+      printFileSize: { diff: true }
+    },
+    splitChunks: { preset: 'default' },
+    server: { port, strictPort: true, printUrls: false },
+    dev: { writeToDisk: (file) => file.includes('manifest.json') }
+  }
+}
+
+module.exports = { createDefaultRsbuildConfig }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "sails-hook-shipwright",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sails-hook-shipwright",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@rsbuild/core": "^1.7.3",
+        "@rsbuild/core": "^2.0.6",
         "fast-glob": "^3.3.3"
       },
       "devDependencies": {
@@ -18,6 +18,9 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "prettier": "^3.8.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -302,20 +305,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -323,78 +326,31 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@module-federation/error-codes": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
-      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/runtime": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
-      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.22.0",
-        "@module-federation/runtime-core": "0.22.0",
-        "@module-federation/sdk": "0.22.0"
-      }
-    },
-    "node_modules/@module-federation/runtime-core": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
-      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.22.0",
-        "@module-federation/sdk": "0.22.0"
-      }
-    },
-    "node_modules/@module-federation/runtime-tools": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
-      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.22.0",
-        "@module-federation/webpack-bundler-runtime": "0.22.0"
-      }
-    },
-    "node_modules/@module-federation/sdk": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
-      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
-      "license": "MIT"
-    },
-    "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
-      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.22.0",
-        "@module-federation/sdk": "0.22.0"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
-      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.5.0",
-        "@emnapi/runtime": "^1.5.0",
         "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -433,46 +389,51 @@
       }
     },
     "node_modules/@rsbuild/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-2.0.6.tgz",
+      "integrity": "sha512-0/u7oTgPp9NsL7E7qXzYiOOPAsOJiDbOr0FmG6gizJDIpYK8nospogNrwQ00SG0had9fdhLI7XkhP160IaLnWw==",
       "license": "MIT",
       "dependencies": {
-        "@rspack/core": "~1.7.5",
-        "@rspack/lite-tapable": "~1.1.0",
-        "@swc/helpers": "^0.5.18",
-        "core-js": "~3.47.0",
-        "jiti": "^2.6.1"
+        "@rspack/core": "~2.0.3",
+        "@swc/helpers": "^0.5.21"
       },
       "bin": {
         "rsbuild": "bin/rsbuild.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "core-js": ">= 3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "core-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rspack/binding": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.6.tgz",
-      "integrity": "sha512-/NrEcfo8Gx22hLGysanrV6gHMuqZSxToSci/3M4kzEQtF5cPjfOv5pqeLK/+B6cr56ul/OmE96cCdWcXeVnFjQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-2.0.3.tgz",
+      "integrity": "sha512-4exVNhGhW5RFHjK87XeTKbkA/qAgI5NHJlT1jNqiJv0gcUXLqTOEU3w7f8+f9zUo4JMFvPc0c9veOi4M19YYTg==",
       "license": "MIT",
       "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.7.6",
-        "@rspack/binding-darwin-x64": "1.7.6",
-        "@rspack/binding-linux-arm64-gnu": "1.7.6",
-        "@rspack/binding-linux-arm64-musl": "1.7.6",
-        "@rspack/binding-linux-x64-gnu": "1.7.6",
-        "@rspack/binding-linux-x64-musl": "1.7.6",
-        "@rspack/binding-wasm32-wasi": "1.7.6",
-        "@rspack/binding-win32-arm64-msvc": "1.7.6",
-        "@rspack/binding-win32-ia32-msvc": "1.7.6",
-        "@rspack/binding-win32-x64-msvc": "1.7.6"
+        "@rspack/binding-darwin-arm64": "2.0.3",
+        "@rspack/binding-darwin-x64": "2.0.3",
+        "@rspack/binding-linux-arm64-gnu": "2.0.3",
+        "@rspack/binding-linux-arm64-musl": "2.0.3",
+        "@rspack/binding-linux-x64-gnu": "2.0.3",
+        "@rspack/binding-linux-x64-musl": "2.0.3",
+        "@rspack/binding-wasm32-wasi": "2.0.3",
+        "@rspack/binding-win32-arm64-msvc": "2.0.3",
+        "@rspack/binding-win32-ia32-msvc": "2.0.3",
+        "@rspack/binding-win32-x64-msvc": "2.0.3"
       }
     },
     "node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.6.tgz",
-      "integrity": "sha512-NZ9AWtB1COLUX1tA9HQQvWpTy07NSFfKBU8A6ylWd5KH8AePZztpNgLLAVPTuNO4CZXYpwcoclf8jG/luJcQdQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-2.0.3.tgz",
+      "integrity": "sha512-4UyCjLJwU/WxR6K1/gG4u3+jUsoaRHJ5rNu9fto/UbvrItwdlVNULChAApqZFw6mcSetMddSjSICeuj5pSB6sA==",
       "cpu": [
         "arm64"
       ],
@@ -483,9 +444,9 @@
       ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.6.tgz",
-      "integrity": "sha512-J2g6xk8ZS7uc024dNTGTHxoFzFovAZIRixUG7PiciLKTMP78svbSSWrmW6N8oAsAkzYfJWwQpVgWfFNRHvYxSw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-2.0.3.tgz",
+      "integrity": "sha512-K3evrbTgZNa8emEqk+AjDtbuoXZp5tPZz3pcEgETxuu3KanW8Zu+Fb+TUp1DEUcL0xOmHPPox8H2cZ3pF4Zmug==",
       "cpu": [
         "x64"
       ],
@@ -496,11 +457,14 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.6.tgz",
-      "integrity": "sha512-eQfcsaxhFrv5FmtaA7+O1F9/2yFDNIoPZzV/ZvqvFz5bBXVc4FAm/1fVpBg8Po/kX1h0chBc7Xkpry3cabFW8w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-2.0.3.tgz",
+      "integrity": "sha512-aPLDaaTtX1wqjLYAIHc2MGDQZtv1Hbjx47oaaefbWz5GbAnSA4P8jdYIeeGRyrqvQ0WqJXIWXgT0d/iXtes00A==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -509,11 +473,14 @@
       ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.6.tgz",
-      "integrity": "sha512-DfQXKiyPIl7i1yECHy4eAkSmlUzzsSAbOjgMuKn7pudsWf483jg0UUYutNgXSlBjc/QSUp7906Cg8oty9OfwPA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-2.0.3.tgz",
+      "integrity": "sha512-0WulUQPop6vmSDfrTxghmVlm+6crU8/XqD2f0dOWbEniZVuDZJ5/Y/cBqTRyk3rjl0vrmUv3lc87/t7UgQJQSw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -522,11 +489,14 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.6.tgz",
-      "integrity": "sha512-NdA+2X3lk2GGrMMnTGyYTzM3pn+zNjaqXqlgKmFBXvjfZqzSsKq3pdD1KHZCd5QHN+Fwvoszj0JFsquEVhE1og==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-2.0.3.tgz",
+      "integrity": "sha512-fAhiMuV5omT53YMft+f3Y9euAFgspuyBAk9ZpeW2buL2TkuUMwP07adhhvQfKdQ5gpELfzmjQaRDGqaIT8UWiA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -535,11 +505,14 @@
       ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.6.tgz",
-      "integrity": "sha512-rEy6MHKob02t/77YNgr6dREyJ0e0tv1X6Xsg8Z5E7rPXead06zefUbfazj4RELYySWnM38ovZyJAkPx/gOn3VA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-2.0.3.tgz",
+      "integrity": "sha512-0kcuFoZ8vy2iNWoISFOZt+/Ujo7LRLrzE7h07AV5r+oN/mv+/v14Sd/8NUtDIScCkrYOszYq/QS31e6t0UrVfw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -548,22 +521,24 @@
       ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.6.tgz",
-      "integrity": "sha512-YupOrz0daSG+YBbCIgpDgzfMM38YpChv+afZpaxx5Ml7xPeAZIIdgWmLHnQ2rts73N2M1NspAiBwV00Xx0N4Vg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-2.0.3.tgz",
+      "integrity": "sha512-x2fsw7GzNZEnw444ikj4/b8kVjM0Y0TllxmizHpYZ9gmaQrOk5OXo9RQdz+l4zzoGors0l2IZP5Cc4GJNCaSoQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "1.0.7"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "1.1.4"
       }
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.6.tgz",
-      "integrity": "sha512-INj7aVXjBvlZ84kEhSK4kJ484ub0i+BzgnjDWOWM1K+eFYDZjLdAsQSS3fGGXwVc3qKbPIssFfnftATDMTEJHQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-2.0.3.tgz",
+      "integrity": "sha512-jqlxuVPdrgMuwj/HEjSkC/jmhl4fAuKyob36zJXq2uAusn2FRJ4kClGe1fLFpfxRXFVQAWwlAOwLJg8T0suuaA==",
       "cpu": [
         "arm64"
       ],
@@ -574,9 +549,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.6.tgz",
-      "integrity": "sha512-lXGvC+z67UMcw58In12h8zCa9IyYRmuptUBMItQJzu+M278aMuD1nETyGLL7e4+OZ2lvrnnBIcjXN1hfw2yRzw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-2.0.3.tgz",
+      "integrity": "sha512-QM4JEuyk5QaZ5gnvnAIaCwVQzCkrD2E4Sud77kx/MVGDsRkcOlMx3blMC5QNHPDamRmWGk+7314YOQvRhKuWyg==",
       "cpu": [
         "ia32"
       ],
@@ -587,9 +562,9 @@
       ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.6.tgz",
-      "integrity": "sha512-zeUxEc0ZaPpmaYlCeWcjSJUPuRRySiSHN23oJ2Xyw0jsQ01Qm4OScPdr0RhEOFuK/UE+ANyRtDo4zJsY52Hadw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-2.0.3.tgz",
+      "integrity": "sha512-vSQNnAy0wswG6AfNRuArTHQBiXOXl+A9ddQxBFup4PMHUzXxKtsBLQzw7BgFC0EgrPeHbt+30j7sXVZKYukj4A==",
       "cpu": [
         "x64"
       ],
@@ -600,47 +575,42 @@
       ]
     },
     "node_modules/@rspack/core": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.6.tgz",
-      "integrity": "sha512-Iax6UhrfZqJajA778c1d5DBFbSIqPOSrI34kpNIiNpWd8Jq7mFIa+Z60SQb5ZQDZuUxcCZikjz5BxinFjTkg7Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-2ufO/8FHIA/lX6UOgSsKPhpDvHr0sh9lYq/n/LsIZsTwu3973BGbu2fg1Akvuu3rEnskPqXjsqH2EPBzEA42uA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime-tools": "0.22.0",
-        "@rspack/binding": "1.7.6",
-        "@rspack/lite-tapable": "1.1.0"
+        "@rspack/binding": "2.0.3"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
+        "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0",
         "@swc/helpers": ">=0.5.1"
       },
       "peerDependenciesMeta": {
+        "@module-federation/runtime-tools": {
+          "optional": true
+        },
         "@swc/helpers": {
           "optional": true
         }
       }
     },
-    "node_modules/@rspack/lite-tapable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
-      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
-      "license": "MIT"
-    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -980,24 +950,12 @@
         "node": ">=18"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -1144,9 +1102,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1407,6 +1365,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -1685,9 +1644,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1976,7 +1935,8 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
@@ -2025,9 +1985,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2035,6 +1995,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,11 @@
     "isHook": true,
     "hookName": "shipwright"
   },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "dependencies": {
-    "@rsbuild/core": "^1.7.3",
+    "@rsbuild/core": "^2.0.6",
     "fast-glob": "^3.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "1.2.0",
   "description": "The modern asset pipeline for Sails",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "scripts": {
     "test": "node --test tests/unit/*.test.js",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",

--- a/tests/unit/rsbuild-config.test.js
+++ b/tests/unit/rsbuild-config.test.js
@@ -1,0 +1,130 @@
+const { describe, it, beforeEach, afterEach } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { createDefaultRsbuildConfig } = require('../../lib/rsbuild-config')
+
+const TEST_SAILS_PORT = 1337
+
+describe('rsbuild-config.js', () => {
+  let tmpDir
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipwright-rsbuild-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('uses Rsbuild 2 splitChunks defaults instead of deprecated chunkSplit', () => {
+    const config = createDefaultRsbuildConfig({
+      appPath: '/app',
+      entry: { app: ['/app/assets/js/app.js'] },
+      port: TEST_SAILS_PORT
+    })
+
+    assert.deepStrictEqual(config.splitChunks, { preset: 'default' })
+    assert.strictEqual(config.performance.chunkSplit, undefined)
+    assert.deepStrictEqual(config.performance.printFileSize, { diff: true })
+  })
+
+  it('keeps Shipwright aliases and output paths stable', () => {
+    const config = createDefaultRsbuildConfig({
+      appPath: '/app',
+      entry: { app: ['/app/assets/js/app.js'] },
+      port: TEST_SAILS_PORT
+    })
+
+    assert.strictEqual(
+      config.resolve.alias['@'],
+      path.resolve('/app/assets/js')
+    )
+    assert.strictEqual(config.resolve.alias['~'], path.resolve('/app/assets'))
+    assert.strictEqual(config.output.manifest, true)
+    assert.strictEqual(config.output.distPath.root, '.tmp/public')
+    assert.strictEqual(config.output.distPath.js, 'js')
+    assert.strictEqual(config.output.distPath.css, 'css')
+  })
+
+  it('uses the Sails-supplied port for the Rsbuild dev server config', () => {
+    const config = createDefaultRsbuildConfig({
+      appPath: '/app',
+      entry: { app: ['/app/assets/js/app.js'] },
+      port: TEST_SAILS_PORT
+    })
+
+    assert.strictEqual(config.server.port, TEST_SAILS_PORT)
+    assert.strictEqual(config.server.strictPort, true)
+  })
+
+  it('writes the dev manifest to disk for tag generation', () => {
+    const config = createDefaultRsbuildConfig({
+      appPath: '/app',
+      entry: { app: ['/app/assets/js/app.js'] },
+      port: TEST_SAILS_PORT
+    })
+
+    assert.strictEqual(
+      config.dev.writeToDisk('/app/.tmp/public/manifest.json'),
+      true
+    )
+    assert.strictEqual(
+      config.dev.writeToDisk('/app/.tmp/public/js/app.js'),
+      false
+    )
+  })
+
+  it('keeps Sails-owned static URLs out of css-loader processing', () => {
+    const config = createDefaultRsbuildConfig({
+      appPath: '/app',
+      entry: { app: ['/app/assets/js/app.js'] },
+      port: TEST_SAILS_PORT
+    })
+
+    const filter = config.tools.cssLoader.url.filter
+
+    assert.strictEqual(filter('/images/logo.png'), false)
+    assert.strictEqual(filter('../images/logo.png'), true)
+  })
+
+  it('builds a manifest with Rsbuild 2 for Shipwright tag generation', async () => {
+    const jsPath = path.join(tmpDir, 'assets/js/app.js')
+    const cssPath = path.join(tmpDir, 'assets/css/app.css')
+
+    fs.mkdirSync(path.dirname(jsPath), { recursive: true })
+    fs.mkdirSync(path.dirname(cssPath), { recursive: true })
+    fs.writeFileSync(
+      jsPath,
+      "import '../css/app.css'\ndocument.body.dataset.shipwright = 'ready'\n"
+    )
+    fs.writeFileSync(cssPath, 'body { color: #123456; }\n')
+
+    const { createRsbuild } = await import('@rsbuild/core')
+    const rsbuild = await createRsbuild({
+      cwd: tmpDir,
+      rsbuildConfig: createDefaultRsbuildConfig({
+        appPath: tmpDir,
+        entry: { app: jsPath },
+        port: TEST_SAILS_PORT
+      })
+    })
+
+    await rsbuild.build()
+
+    const manifestPath = path.join(tmpDir, '.tmp/public/manifest.json')
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+
+    assert.ok(Array.isArray(manifest.allFiles))
+    assert.ok(
+      manifest.allFiles.some((file) => file.startsWith('/js/')),
+      'manifest should include a JS file for scripts()'
+    )
+    assert.ok(
+      manifest.allFiles.some((file) => file.startsWith('/css/')),
+      'manifest should include a CSS file for styles()'
+    )
+  })
+})


### PR DESCRIPTION
## What changed

- Upgrades Shipwright to Rsbuild 2 via `@rsbuild/core@^2.0.6`.
- Switches the CommonJS Sails hook to dynamically import Rsbuild ESM.
- Extracts the default Rsbuild config into `lib/rsbuild-config.js`.
- Replaces deprecated `performance.chunkSplit` defaults with `splitChunks: { preset: "default" }`.
- Adds Node runtime docs and Rsbuild 2 migration notes.
- Tightens packed package contents with a `files` allowlist and updates the Husky prepare script.
- Adds unit coverage for the extracted default config and a real Rsbuild 2 production manifest build.

## Validation

- `npm test` passes: 34/34.
- `npm pack` succeeds and includes only README, index.js, lib files, and package.json.
- Packed tarball installed into `africanengineer.com`.
- `africanengineer.com` boots with the packed hook and `@rsbuild/plugin-vue@1.2.8`.
- Explicit Sails-mounted HMR verification completed manually.

Closes #21