### PR TITLE
Use initial manifest entry assets for generated tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,19 +391,33 @@ module.exports.shipwright = {
 
 ### View Helpers
 
-#### `shipwright.scripts()`
+#### `shipwright.scripts([entryName])`
 
 Returns `<script>` tags for:
 
 1. Injected files (from `js.inject` patterns)
-2. Bundled files (from manifest)
+2. Bundled initial files (from manifest)
 
-#### `shipwright.styles()`
+By default, Shipwright emits the `app` entry. Pass an entry name to emit a
+different initial entry from the Rsbuild manifest:
+
+```ejs
+<%- shipwright.scripts('admin') %>
+```
+
+#### `shipwright.styles([entryName])`
 
 Returns `<link>` tags for:
 
 1. Injected files (from `styles.inject` patterns)
-2. Compiled styles (from manifest)
+2. Compiled initial styles (from manifest)
+
+By default, Shipwright emits the `app` entry. Pass an entry name to emit a
+different initial entry from the Rsbuild manifest:
+
+```ejs
+<%- shipwright.styles('admin') %>
+```
 
 ## Troubleshooting
 

--- a/index.js
+++ b/index.js
@@ -61,8 +61,8 @@ module.exports = function defineShipwrightHook(sails) {
     },
 
     // Expose tag generators on hook for other hooks to use
-    scripts: () => tagGenerators?.scripts() || '',
-    styles: () => tagGenerators?.styles() || '',
+    scripts: (entryName) => tagGenerators?.scripts(entryName) || '',
+    styles: (entryName) => tagGenerators?.styles(entryName) || '',
 
     /**
      * Initialize hook.

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -39,27 +39,53 @@ function createTagGenerators(appPath, config = {}) {
   const assetsPath = path.resolve(appPath, 'assets')
   const manifestPath = path.resolve(appPath, '.tmp', 'public', 'manifest.json')
 
-  function getManifest(ext) {
+  function getManifest(ext, entryName = 'app') {
     if (!fs.existsSync(manifestPath)) return []
-    return JSON.parse(fs.readFileSync(manifestPath, 'utf8')).allFiles.filter(
-      (f) => f.endsWith(ext)
-    )
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    const entry = manifest.entries?.[entryName]
+    const kind = ext === '.js' ? 'js' : 'css'
+    const initial = entry?.initial?.[kind]
+
+    if (Array.isArray(initial)) {
+      return initial
+    }
+
+    if (entryName !== 'app') {
+      return []
+    }
+
+    return Array.isArray(manifest.allFiles)
+      ? manifest.allFiles.filter((file) => file.endsWith(ext))
+      : []
   }
 
-  function getTags(ext, template, injectKey) {
+  function getTags(ext, template, injectKey, entryName) {
     const patterns = config[injectKey] || DEFAULT_INJECT[ext.slice(1)]
     const injected = expandPatterns(patterns, assetsPath, ext)
     const injectedSet = new Set(injected)
     // Filter manifest to exclude already-injected files (avoid duplicates)
-    const bundled = getManifest(ext).filter((f) => !injectedSet.has(f))
+    const bundled = getManifest(ext, entryName).filter(
+      (f) => !injectedSet.has(f)
+    )
     return [...injected, ...bundled].map(template).join('\n')
   }
 
   return {
-    scripts: () =>
-      getTags('.js', (f) => `<script src="${f}"></script>`, 'jsInject'),
-    styles: () =>
-      getTags('.css', (f) => `<link rel="stylesheet" href="${f}">`, 'cssInject')
+    scripts: (entryName) =>
+      getTags(
+        '.js',
+        (f) => `<script src="${f}"></script>`,
+        'jsInject',
+        entryName
+      ),
+    styles: (entryName) =>
+      getTags(
+        '.css',
+        (f) => `<link rel="stylesheet" href="${f}">`,
+        'cssInject',
+        entryName
+      )
   }
 }
 

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -1,0 +1,74 @@
+const { describe, it, beforeEach, afterEach } = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const defineShipwrightHook = require('../../index')
+
+describe('index.js', () => {
+  let tmpDir
+  let manifestPath
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shipwright-hook-'))
+    manifestPath = path.join(tmpDir, '.tmp', 'public', 'manifest.json')
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('passes entry names through hook-level tag helpers', () => {
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        entries: {
+          admin: {
+            initial: {
+              js: ['/js/admin.js'],
+              css: ['/css/admin.css']
+            }
+          }
+        },
+        allFiles: [
+          '/js/app.js',
+          '/js/admin.js',
+          '/css/app.css',
+          '/css/admin.css'
+        ]
+      })
+    )
+
+    const sails = {
+      config: {
+        appPath: tmpDir,
+        port: 1337,
+        shipwright: {
+          js: { inject: [] },
+          styles: { inject: [] },
+          build: {}
+        }
+      },
+      log: {
+        silly: () => {},
+        verbose: () => {},
+        warn: () => {}
+      }
+    }
+
+    const hook = defineShipwrightHook(sails)
+
+    hook.configure()
+
+    assert.strictEqual(
+      hook.scripts('admin'),
+      '<script src="/js/admin.js"></script>'
+    )
+    assert.strictEqual(
+      hook.styles('admin'),
+      '<link rel="stylesheet" href="/css/admin.css">'
+    )
+  })
+})

--- a/tests/unit/tags.test.js
+++ b/tests/unit/tags.test.js
@@ -23,7 +23,11 @@ describe('tags.js', () => {
   })
 
   function writeManifest(files) {
-    fs.writeFileSync(manifestPath, JSON.stringify({ allFiles: files }))
+    writeManifestPayload({ allFiles: files })
+  }
+
+  function writeManifestPayload(manifest) {
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest))
   }
 
   function createAsset(relativePath) {
@@ -46,6 +50,73 @@ describe('tags.js', () => {
         scripts(),
         '<script src="/js/app.js"></script>\n<script src="/js/vendor.js"></script>'
       )
+    })
+
+    it('uses initial JS entry assets without async chunks', () => {
+      writeManifestPayload({
+        entries: {
+          app: {
+            initial: {
+              js: ['/js/app.js', '/js/vendor.js'],
+              css: ['/css/app.css']
+            },
+            async: {
+              js: ['/js/pages/dashboard.js'],
+              css: ['/css/pages/dashboard.css']
+            }
+          }
+        },
+        allFiles: [
+          '/js/app.js',
+          '/js/vendor.js',
+          '/js/pages/dashboard.js',
+          '/css/app.css',
+          '/css/pages/dashboard.css'
+        ]
+      })
+      const { scripts } = createTagGenerators(tmpDir, { jsInject: [] })
+
+      const output = scripts()
+      assert.strictEqual(
+        output,
+        '<script src="/js/app.js"></script>\n<script src="/js/vendor.js"></script>'
+      )
+      assert.ok(!output.includes('/js/pages/dashboard.js'))
+    })
+
+    it('supports named JS entries', () => {
+      writeManifestPayload({
+        entries: {
+          app: {
+            initial: {
+              js: ['/js/app.js']
+            }
+          },
+          admin: {
+            initial: {
+              js: ['/js/admin.js', '/js/admin-vendor.js']
+            },
+            async: {
+              js: ['/js/pages/admin-settings.js']
+            }
+          }
+        },
+        allFiles: [
+          '/js/app.js',
+          '/js/admin.js',
+          '/js/admin-vendor.js',
+          '/js/pages/admin-settings.js'
+        ]
+      })
+      const { scripts } = createTagGenerators(tmpDir, { jsInject: [] })
+
+      const output = scripts('admin')
+      assert.strictEqual(
+        output,
+        '<script src="/js/admin.js"></script>\n<script src="/js/admin-vendor.js"></script>'
+      )
+      assert.ok(!output.includes('/js/app.js'))
+      assert.ok(!output.includes('/js/pages/admin-settings.js'))
     })
 
     it('uses default inject pattern when not specified', () => {
@@ -85,6 +156,40 @@ describe('tags.js', () => {
       assert.ok(sailsIdx < lodashIdx, 'sails.io should come before lodash')
       assert.ok(lodashIdx < vueIdx, 'lodash should come before vue')
       assert.ok(vueIdx < appIdx, 'vue should come before app.js')
+    })
+
+    it('injects files before initial manifest assets and removes duplicates', () => {
+      createAsset('dependencies/sails.io.js')
+      writeManifestPayload({
+        entries: {
+          app: {
+            initial: {
+              js: ['/dependencies/sails.io.js', '/js/app.js']
+            },
+            async: {
+              js: ['/js/pages/dashboard.js']
+            }
+          }
+        },
+        allFiles: [
+          '/dependencies/sails.io.js',
+          '/js/app.js',
+          '/js/pages/dashboard.js'
+        ]
+      })
+
+      const { scripts } = createTagGenerators(tmpDir, {
+        jsInject: ['dependencies/sails.io.js']
+      })
+
+      const output = scripts()
+      const matches = output.match(/sails\.io\.js/g) || []
+      assert.strictEqual(matches.length, 1, 'sails.io should appear only once')
+      assert.ok(
+        output.indexOf('sails.io.js') < output.indexOf('/js/app.js'),
+        'injected JS should come before manifest JS'
+      )
+      assert.ok(!output.includes('/js/pages/dashboard.js'))
     })
 
     it('supports glob patterns with deduplication', () => {
@@ -141,6 +246,73 @@ describe('tags.js', () => {
       )
     })
 
+    it('uses initial CSS entry assets without async chunks', () => {
+      writeManifestPayload({
+        entries: {
+          app: {
+            initial: {
+              js: ['/js/app.js'],
+              css: ['/css/app.css', '/css/vendor.css']
+            },
+            async: {
+              js: ['/js/pages/dashboard.js'],
+              css: ['/css/pages/dashboard.css']
+            }
+          }
+        },
+        allFiles: [
+          '/js/app.js',
+          '/js/pages/dashboard.js',
+          '/css/app.css',
+          '/css/vendor.css',
+          '/css/pages/dashboard.css'
+        ]
+      })
+      const { styles } = createTagGenerators(tmpDir, { cssInject: [] })
+
+      const output = styles()
+      assert.strictEqual(
+        output,
+        '<link rel="stylesheet" href="/css/app.css">\n<link rel="stylesheet" href="/css/vendor.css">'
+      )
+      assert.ok(!output.includes('/css/pages/dashboard.css'))
+    })
+
+    it('supports named CSS entries', () => {
+      writeManifestPayload({
+        entries: {
+          app: {
+            initial: {
+              css: ['/css/app.css']
+            }
+          },
+          admin: {
+            initial: {
+              css: ['/css/admin.css', '/css/admin-vendor.css']
+            },
+            async: {
+              css: ['/css/pages/admin-settings.css']
+            }
+          }
+        },
+        allFiles: [
+          '/css/app.css',
+          '/css/admin.css',
+          '/css/admin-vendor.css',
+          '/css/pages/admin-settings.css'
+        ]
+      })
+      const { styles } = createTagGenerators(tmpDir, { cssInject: [] })
+
+      const output = styles('admin')
+      assert.strictEqual(
+        output,
+        '<link rel="stylesheet" href="/css/admin.css">\n<link rel="stylesheet" href="/css/admin-vendor.css">'
+      )
+      assert.ok(!output.includes('/css/app.css'))
+      assert.ok(!output.includes('/css/pages/admin-settings.css'))
+    })
+
     it('uses default inject pattern when not specified', () => {
       createAsset('dependencies/normalize.css')
       writeManifest(['/css/app.css'])
@@ -170,6 +342,92 @@ describe('tags.js', () => {
         'injected CSS should come before manifest'
       )
     })
+
+    it('injects CSS before initial manifest assets and removes duplicates', () => {
+      createAsset('dependencies/normalize.css')
+      writeManifestPayload({
+        entries: {
+          app: {
+            initial: {
+              css: ['/dependencies/normalize.css', '/css/app.css']
+            },
+            async: {
+              css: ['/css/pages/dashboard.css']
+            }
+          }
+        },
+        allFiles: [
+          '/dependencies/normalize.css',
+          '/css/app.css',
+          '/css/pages/dashboard.css'
+        ]
+      })
+
+      const { styles } = createTagGenerators(tmpDir, {
+        cssInject: ['dependencies/normalize.css']
+      })
+
+      const output = styles()
+      const matches = output.match(/normalize\.css/g) || []
+      assert.strictEqual(
+        matches.length,
+        1,
+        'normalize.css should appear only once'
+      )
+      assert.ok(
+        output.indexOf('normalize.css') < output.indexOf('/css/app.css'),
+        'injected CSS should come before manifest CSS'
+      )
+      assert.ok(!output.includes('/css/pages/dashboard.css'))
+    })
+  })
+
+  it('falls back to allFiles when entries are missing', () => {
+    writeManifest(['/js/app.js', '/css/app.css', '/images/logo.svg'])
+    const { scripts, styles } = createTagGenerators(tmpDir, {
+      jsInject: [],
+      cssInject: []
+    })
+
+    assert.strictEqual(scripts(), '<script src="/js/app.js"></script>')
+    assert.strictEqual(styles(), '<link rel="stylesheet" href="/css/app.css">')
+  })
+
+  it('falls back to allFiles when the default entry initial assets are missing', () => {
+    writeManifestPayload({
+      entries: {
+        app: {}
+      },
+      allFiles: ['/js/app.js', '/css/app.css', '/images/logo.svg']
+    })
+    const { scripts, styles } = createTagGenerators(tmpDir, {
+      jsInject: [],
+      cssInject: []
+    })
+
+    assert.strictEqual(scripts(), '<script src="/js/app.js"></script>')
+    assert.strictEqual(styles(), '<link rel="stylesheet" href="/css/app.css">')
+  })
+
+  it('does not fall back to allFiles for missing named entries', () => {
+    writeManifestPayload({
+      entries: {
+        app: {
+          initial: {
+            js: ['/js/app.js'],
+            css: ['/css/app.css']
+          }
+        }
+      },
+      allFiles: ['/js/app.js', '/js/admin.js', '/css/app.css', '/css/admin.css']
+    })
+    const { scripts, styles } = createTagGenerators(tmpDir, {
+      jsInject: [],
+      cssInject: []
+    })
+
+    assert.strictEqual(scripts('admin'), '')
+    assert.strictEqual(styles('admin'), '')
   })
 
   it('reads fresh manifest on each call (no caching)', () => {


### PR DESCRIPTION
## Summary

- Emit only initial JS/CSS assets from Rsbuild manifest entries for `shipwright.scripts()` and `shipwright.styles()`.
- Avoid globally injecting async chunks while keeping the default `app` fallback to older `allFiles` manifests.
- Add optional named entry support: `shipwright.scripts(entryName)` and `shipwright.styles(entryName)` accept any string matching a key in `manifest.entries`, for example `shipwright.scripts("marketing")` or `shipwright.styles("admin")`.
- Missing named entries return no manifest assets instead of falling back to `allFiles`, so named layouts do not accidentally emit unrelated chunks.

## Testing

- `npm test`
- `npx prettier --check README.md index.js lib/tags.js tests/unit/tags.test.js tests/unit/index.test.js`

Closes #23